### PR TITLE
[1주차] 섀넌

### DIFF
--- a/TEAM B - Morning/Week 1/Shnnon/[1주차] 섀넌 ipynb.ipynb
+++ b/TEAM B - Morning/Week 1/Shnnon/[1주차] 섀넌 ipynb.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5c072816",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 2920 음계\n",
+    "# https://www.acmicpc.net/problem/2920\n",
+    "# 문제풀이 방법 : 리스트에서 원소를 차례대로 비교하면서, 비교할 때 두 원소를 기준을 오름차순, 내림차순 여부를 체크함\n",
+    "# 오름 차순 및 내림차순이 모두 false일 때 mixed를 출력함 \n",
+    "\n",
+    "a = list(map(int, input().split(' ')))\n",
+    "\n",
+    "ascending = True\n",
+    "descending = True\n",
+    "\n",
+    "for i in range(1,8):\n",
+    "    if a[i] > a[i-1] :\n",
+    "        descending = False\n",
+    "    elif a[i] < a[i-1] :\n",
+    "        ascending = False\n",
+    "\n",
+    "if ascending : \n",
+    "    print('ascending')\n",
+    "elif descending : \n",
+    "    print('descending')\n",
+    "else :\n",
+    "    print('mixed')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2a2bcd3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#2798 블랙잭\n",
+    "# https://www.acmicpc.net/problem/2798\n",
+    "# c(m,3) 일때, 최대의 수가 100만인데, 파이썬은 1초에 2000만 정도의 연산을 수행하니 그냥 풀어도 상관 없을듯\n",
+    "\n",
+    "n,m = list(map(int,input().split(' ')))\n",
+    "data = list(map(int, input().split(' ')))\n",
+    "\n",
+    "result = 0\n",
+    "length = len(data)\n",
+    "\n",
+    "count = 0\n",
+    "for i in range(0, length):\n",
+    "    for j in range(i+1, length):\n",
+    "        for k in range(j+1, length):\n",
+    "            sum_value = data[i]+data[j]+data[k]\n",
+    "            if sum_value <= m:\n",
+    "                result = max(result, sum_value)\n",
+    "\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "588f7300",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 1874_스택수열 \n",
+    "# https://www.acmicpc.net/problem/1874\n",
+    "# 스택에서 원소를 삽읿할 때는, 단순히 특정 수에 도달할때까지 삽입하면 됨, 스택에서 원소를 연달아 빼낼 때 내림차순으로 유지할 수 있는지 확인해야 함 \n",
+    "\n",
+    "\n",
+    "#그런데 런타임에러남,, \n",
+    "import sys\n",
+    "\n",
+    "\n",
+    "n = int(sys.stdin.readline())\n",
+    "\n",
+    "n = int(input())\n",
+    "count = 1\n",
+    "stack = [] \n",
+    "result = []\n",
+    "\n",
+    "for i in range(1, n+1): #데이터 개수만큼반복\n",
+    "    data = int(intput())\n",
+    "    while count <= data : #입력받은 데이터에 도달할때까지 삽입\n",
+    "        stack.append(count)\n",
+    "        count += 1\n",
+    "        result.append('+')\n",
+    "        if stack[-1] == data: #stack의 최상위 원소가 데이터와 같을때 출력\n",
+    "            stack.pop()\n",
+    "            result.append('-')\n",
+    "        else: #불가능한 경우 \n",
+    "            print('NO')\n",
+    "            exit(0)\n",
+    "\n",
+    "print('\\n'.join(result()))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### 2920 음계
- https://www.acmicpc.net/problem/2920
- 문제풀이 방법 : 리스트에서 원소를 차례대로 비교하면서, 비교할 때 두 원소를 기준을 오름차순, 내림차순 여부를 체크함
- 오름 차순 및 내림차순이 모두 false일 때 mixed를 출력함 


### 2798 블랙잭
- https://www.acmicpc.net/problem/2798
-  c(m,3) 일때, 최대의 수가 100만인데, 파이썬은 1초에 2000만 정도의 연산을 수행하니 그냥 풀어도 상관 없을듯

### 1874_스택수열 
- https://www.acmicpc.net/problem/1874
- 스택에서 원소를 삽읿할 때는, 단순히 특정 수에 도달할때까지 삽입하면 됨, 스택에서 원소를 연달아 빼낼 때 내림차순으로 유지할 수 있는지 확인해야 함 
- 그런데 런타임에러남,, 

